### PR TITLE
fix: conditionalize dracut services for anaconda

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,25 @@ all:
 .PHONY: install
 install:
 	install -D -m 0644 -t $(DESTDIR)/usr/lib/dracut/modules.d/35ignition-edge \
-		dracut/35ignition-edge/*.service
+		dracut/35ignition-edge/coreos-enable-network.service
 	install -D -m 0755 -t $(DESTDIR)/usr/lib/dracut/modules.d/35ignition-edge \
-		dracut/35ignition-edge/*.sh
+		dracut/35ignition-edge/coreos-enable-network.sh
+	install -D -m 0644 -t $(DESTDIR)/usr/lib/dracut/modules.d/35ignition-edge \
+		dracut/35ignition-edge/coreos-teardown-initramfs.service
+	install -D -m 0755 -t $(DESTDIR)/usr/lib/dracut/modules.d/35ignition-edge \
+		dracut/35ignition-edge/coreos-teardown-initramfs.sh
+	install -D -m 0644 -t $(DESTDIR)/usr/lib/dracut/modules.d/35ignition-edge \
+		dracut/35ignition-edge/ignition-setup-user.service
+	install -D -m 0755 -t $(DESTDIR)/usr/lib/dracut/modules.d/35ignition-edge \
+		dracut/35ignition-edge/ignition-setup-user.sh
+	install -D -m 0644 -t $(DESTDIR)/usr/lib/dracut/modules.d/35ignition-edge \
+		dracut/35ignition-edge/ignition-ostree-mount-var.service
+	install -D -m 0755 -t $(DESTDIR)/usr/lib/dracut/modules.d/35ignition-edge \
+		dracut/35ignition-edge/ignition-ostree-mount-var.sh
+	install -D -m 0755 -t $(DESTDIR)/usr/lib/dracut/modules.d/35ignition-edge \
+		dracut/35ignition-edge/module-setup.sh
+	install -D -m 0755 -t $(DESTDIR)/usr/lib/dracut/modules.d/35ignition-edge \
+		dracut/35ignition-edge/ignition-edge-generator
 	install -D -m 0644 -t $(DESTDIR)/usr/lib/dracut/modules.d/99emergency-shell-setup \
 		dracut/99emergency-shell-setup/*.service
 	install -D -m 0755 -t $(DESTDIR)/usr/lib/dracut/modules.d/99emergency-shell-setup \

--- a/dracut/35ignition-edge/ignition-edge-generator
+++ b/dracut/35ignition-edge/ignition-edge-generator
@@ -1,0 +1,49 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+set -e
+
+# Generators don't have logging right now
+# https://github.com/systemd/systemd/issues/15638
+exec 1>/dev/kmsg; exec 2>&1
+
+UNIT_DIR="${1:-/tmp}"
+
+cmdline=( $(</proc/cmdline) )
+cmdline_arg() {
+    local name="$1" value="$2"
+    for arg in "${cmdline[@]}"; do
+        if [[ "${arg%%=*}" == "${name}" ]]; then
+            value="${arg#*=}"
+        fi
+    done
+    echo "${value}"
+}
+
+cmdline_bool() {
+    local value=$(cmdline_arg "$@")
+    case "$value" in
+        ""|0|no|off) return 1;;
+        *) return 0;;
+    esac
+}
+
+add_requires() {
+    local name="$1"; shift
+    local target="$1"; shift
+    local requires_dir="${UNIT_DIR}/${target}.requires"
+    mkdir -p "${requires_dir}"
+    ln -sf "../${name}" "${requires_dir}/${name}"
+}
+
+if ! $(cmdline_bool 'ignition.firstboot' 0); then
+    exit 0
+fi
+
+mkdir -p "${UNIT_DIR}/ignition-setup-user.service.d"
+cat > "${UNIT_DIR}/ignition-setup-user.service.d/diskful.conf" <<EOF
+[Unit]
+Requires=dev-disk-by\x2dlabel-boot.device
+After=dev-disk-by\x2dlabel-boot.device
+EOF

--- a/dracut/35ignition-edge/ignition-setup-user.service
+++ b/dracut/35ignition-edge/ignition-setup-user.service
@@ -10,9 +10,6 @@ Before=ignition-fetch-offline.service
 OnFailure=emergency.target
 OnFailureJobMode=isolate
 
-Requires=dev-disk-by\x2dlabel-boot.device
-After=dev-disk-by\x2dlabel-boot.device
-
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/dracut/35ignition-edge/module-setup.sh
+++ b/dracut/35ignition-edge/module-setup.sh
@@ -26,6 +26,9 @@ install() {
         realpath \
         sgdisk
 
+    inst_simple "$moddir/ignition-edge-generator" \
+        "$systemdutildir/system-generators/ignition-edge-generator"
+
     inst_script "$moddir/ignition-setup-user.sh" \
         "/usr/sbin/ignition-setup-user"
     install_ignition_unit ignition-setup-user.service
@@ -42,6 +45,5 @@ install() {
 
     inst_simple "$moddir/coreos-enable-network.sh" \
         "/usr/sbin/coreos-enable-network"
-    install_ignition_unit "coreos-enable-network.service" \
-        "initrd.target"
+    install_ignition_unit "coreos-enable-network.service"
 }


### PR DESCRIPTION
This patch contains a fix for the enablement of
coreos-enable-network.service - it used to depend on the initrd.target
which was just completely wrong and just a bug/error. Fixing that makes
the system work with anaconda again.
Added a generator to make sure the setup user service doesn't depend on
the boot device if we're not gonna run ignition.
Also, just rewrote the Makefile to make sure it's easier to debug in the
future.
