### PR TITLE
Remount /usr to enable ignition directory writing

### DIFF
--- a/dracut/35ignition-edge/ignition-setup-user.sh
+++ b/dracut/35ignition-edge/ignition-setup-user.sh
@@ -11,6 +11,10 @@ copy_file_if_exists() {
     fi
 }
 
+if [ ! -w /usr ]; then
+    mount -o rw,remount /usr
+fi
+
 destination=/usr/lib/ignition
 mkdir -p $destination
 


### PR DESCRIPTION
Remounts /usr if needed to allow ignition directory writing as intended. 

Fixes https://github.com/fedora-iot/iot-distro/issues/77

Fix inspired by: https://github.com/coreos/fedora-coreos-config/pull/3031 and https://github.com/coreos/fedora-coreos-config/pull/3077

See also: https://github.com/coreos/ignition/issues/1891