### PR TITLE
fix: add missing coreos-relabel script to fix boot failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ install:
 		dracut/35ignition-edge/coreos-enable-network.service
 	install -D -m 0755 -t $(DESTDIR)/usr/lib/dracut/modules.d/35ignition-edge \
 		dracut/35ignition-edge/coreos-enable-network.sh
+	install -D -m 0755 -t $(DESTDIR)/usr/lib/dracut/modules.d/35ignition-edge \
+		dracut/35ignition-edge/coreos-relabel
 	install -D -m 0644 -t $(DESTDIR)/usr/lib/dracut/modules.d/35ignition-edge \
 		dracut/35ignition-edge/coreos-teardown-initramfs.service
 	install -D -m 0755 -t $(DESTDIR)/usr/lib/dracut/modules.d/35ignition-edge \
@@ -45,6 +47,8 @@ install:
 	install -D -m 0644 -t $(DESTDIR)/usr/lib/systemd/system systemd/coreos-check-ssh-keys.service
 	install -D -m 0755 -t $(DESTDIR)/usr/libexec \
 		scripts/coreos-check-ssh-keys
+	install -D -m 0644 -t $(DESTDIR)/usr/share/licenses/ignition-edge \
+		LICENSE
 
 
 RPM_SPECFILE=rpmbuild/SPECS/ignition-edge-$(COMMIT).spec

--- a/dracut/35ignition-edge/coreos-relabel
+++ b/dracut/35ignition-edge/coreos-relabel
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+err() {
+ echo "$@" >&2
+}
+
+fatal() {
+ err "$@"
+ exit 1
+}
+
+if [ $# -eq 0 ]; then
+ err "Usage: $0 [PATTERN...]"
+ err " e.g.: $0 /etc/passwd '/etc/group*'"
+fi
+
+if [ ! -f /sysroot/etc/selinux/config ]; then
+ exit 0
+fi
+
+source /sysroot/etc/selinux/config
+
+if [ -z "${SELINUXTYPE:-}" ]; then
+ fatal "Couldn't find SELINUXTYPE in /sysroot/etc/selinux/config"
+fi
+
+file_contexts="/sysroot/etc/selinux/${SELINUXTYPE}/contexts/files/file_contexts"
+
+prefixed_patterns=()
+while [ $# -ne 0 ]; do
+ pattern=$1; shift
+ prefixed_patterns+=("/sysroot/$pattern")
+done
+setfiles -vFi0 -r /sysroot "$file_contexts" "${prefixed_patterns[@]}"

--- a/dracut/35ignition-edge/module-setup.sh
+++ b/dracut/35ignition-edge/module-setup.sh
@@ -24,7 +24,8 @@ install() {
         sed \
         grep \
         realpath \
-        sgdisk
+        sgdisk \
+        setfiles
 
     inst_simple "$moddir/ignition-edge-generator" \
         "$systemdutildir/system-generators/ignition-edge-generator"
@@ -32,6 +33,9 @@ install() {
     inst_script "$moddir/ignition-setup-user.sh" \
         "/usr/sbin/ignition-setup-user"
     install_ignition_unit ignition-setup-user.service
+
+    inst_script "$moddir/coreos-relabel" \
+        "/usr/sbin/coreos-relabel"
 
     inst_script "$moddir/coreos-teardown-initramfs.sh" \
         "/usr/sbin/coreos-teardown-initramfs"


### PR DESCRIPTION
Add the coreos-relabel SELinux relabeling script from upstream fedora-coreos-config to resolve initramfs boot failures.

The coreos-teardown-initramfs.sh script calls coreos-relabel to properly set SELinux contexts on files created during Ignition configuration. Without this script, the initramfs panics and drops to an emergency shell.

Changes:
- Add dracut/35ignition-edge/coreos-relabel script
- Update module-setup.sh to install coreos-relabel and setfiles
- Update Makefile to include coreos-relabel in installation

Fixes: https://github.com/fedora-iot/ignition-edge/issues/6