### PR TITLE
fix: remove sgdisk dependency from ignition-edge dracut module

### DIFF
--- a/dracut/35ignition-edge/module-setup.sh
+++ b/dracut/35ignition-edge/module-setup.sh
@@ -24,7 +24,6 @@ install() {
         sed \
         grep \
         realpath \
-        sgdisk \
         setfiles
 
     inst_simple "$moddir/ignition-edge-generator" \


### PR DESCRIPTION
The ignition-edge dracut module requires sgdisk, but gdisk was removed from RHEL 10, causing initramfs rebuild failures.

This dependency is redundant since the ignition binary has vendored gdisk internally since ignition-2.17.0-6 (August 2024).

Resolves: RHEL-155118

Assisted by Claude.